### PR TITLE
Bug correction

### DIFF
--- a/src/napari_swc_editor/_widget.py
+++ b/src/napari_swc_editor/_widget.py
@@ -47,9 +47,9 @@ class SWCEditorWidget(Container):
         )
         self._link_previous_node_checkbox = create_widget(
             label="link previous node with new node (same as using CTRL+Click)",
-            annotation=float,
             widget_type="CheckBox",
         )
+
         self._show_table_button = create_widget(
             label="Show swc table", annotation=bool, widget_type="PushButton"
         )
@@ -57,10 +57,10 @@ class SWCEditorWidget(Container):
         self._get_layer_data()
 
         # connect your own callbacks
+        self._point_layer_combo.changed.connect(self._get_layer_data)
         self._link_previous_node_checkbox.changed.connect(
             self._set_link_previous_node
         )
-        self._link_previous_node_checkbox.changed.connect(self._get_layer_data)
 
         self._show_table_button.changed.connect(self._set_table)
 
@@ -123,7 +123,7 @@ class SWCEditorWidget(Container):
         layer = self._point_layer_combo.value
         if layer is None:
             return
-        layer.metadata["link_previous_node"] = value
+        layer.metadata["widget_link_activated"] = value
 
     def _table_clicked(self, event):
         row = event.row()

--- a/src/napari_swc_editor/bindings.py
+++ b/src/napari_swc_editor/bindings.py
@@ -133,8 +133,12 @@ def event_add_points(event):
                 0
             ]
 
+        structure_id = symbol_to_structure_id(
+            [structure.value for structure in new_structure]
+        )
+
         new_swc, df = add_points(
-            raw_swc, new_pos, new_radius, new_structure, new_parents, df
+            raw_swc, new_pos, new_radius, structure_id, new_parents, df
         )
 
         event.source.metadata["raw_swc"] = new_swc

--- a/src/napari_swc_editor/bindings.py
+++ b/src/napari_swc_editor/bindings.py
@@ -125,7 +125,7 @@ def event_add_points(event):
         # if shift is activated, the add the new edges from previous selected point
         if (
             event.source.metadata["Ctrl_activated"]
-            or event.source.metadata["link_previous_node"]
+            or event.source.metadata["widget_link_activated"]
         ) and len(event.source.selected_data) > 0:
 
             previous_selected = list(event.source.selected_data)[-1]


### PR DESCRIPTION
- Binding widget was broken, you can now use it to link point without pressing CTRL all the time
- Bug correction when creating new point where napari structure (disk, sphere, etc...) was written rather than 1, 2, 3, swc structure_id